### PR TITLE
Update GenericCloner.java

### DIFF
--- a/src/main/java/org/jboss/tfonteyne/profilecloner/GenericCloner.java
+++ b/src/main/java/org/jboss/tfonteyne/profilecloner/GenericCloner.java
@@ -377,7 +377,7 @@ public class GenericCloner implements Cloner {
      * @return
      */
     private String escape(ModelNode value) {
-        return "\"" + value.asString().replaceAll("=", "\\=").replaceAll("\"", "\\") + "\"";
+        return "\"" + value.asString().replace("=", "\\=").replace("\"", "\\") + "\"";
     }
 
     // for ease of use all loops add commas so cut it off when done

--- a/src/main/java/org/jboss/tfonteyne/profilecloner/GenericCloner.java
+++ b/src/main/java/org/jboss/tfonteyne/profilecloner/GenericCloner.java
@@ -377,7 +377,7 @@ public class GenericCloner implements Cloner {
      * @return
      */
     private String escape(ModelNode value) {
-        return "\"" + value.asString().replace("=", "\\=").replace("\"", "\\") + "\"";
+        return "\"" + value.asString().replace("=", "\\=").replace("\"", "\\\") + "\"";
     }
 
     // for ease of use all loops add commas so cut it off when done


### PR DESCRIPTION
The tool breaks with any argument in the profile containing escaped strings with
```
java.lang.IllegalArgumentException: character to be escaped is missing
        at java.util.regex.Matcher.appendReplacement(Matcher.java:809)
        at java.util.regex.Matcher.replaceAll(Matcher.java:955)
        at java.lang.String.replaceAll(String.java:2223)
        at org.jboss.tfonteyne.profilecloner.GenericCloner.escape(GenericCloner.java:360)
```
It's because of the used literals, but I think the core is using  replaceAll  instead of  replace and was just a typo here, because there's no needs for RegExp's.

update: And there was an additional bug in the 2nd replacement